### PR TITLE
feat: add vercel.json for SPA routing and production deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Adds vercel.json with a catch-all rewrite rule so React Router handles
client-side navigation correctly — direct URL access and page refreshes
on any route will return index.html instead of a 404.

Closes #10

https://claude.ai/code/session_01QV63cnaAxENP52ikC6Vgew