### PR TITLE
feat(#8): add Supabase persistence, auth, and data layer

### DIFF
--- a/apps/web/src/app/AppContext.tsx
+++ b/apps/web/src/app/AppContext.tsx
@@ -1,5 +1,18 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { INBOX, INSIGHTS, TRIP_DETAILS, TRIPS } from '../lib/data';
+import { INBOX, INSIGHTS, TRIP_DETAILS, TRAVELERS, TRIPS } from '../lib/data';
+import {
+  deleteInboxItem,
+  deleteInsight,
+  fetchInboxItems,
+  fetchInsights,
+  fetchTripDetails,
+  fetchTrips,
+  hasSeededData,
+  seedFromFixtures,
+  subscribeAuthChange,
+  upsertTrip,
+  upsertTripDetail,
+} from '../lib/db';
 import type { InboxItem, Insight, Trip, TripDetail, TripStage } from '../lib/types';
 
 type AccentKey = 'orange' | 'olive' | 'blue' | 'plum' | 'sand';
@@ -27,6 +40,7 @@ type AppState = {
   tweaksOpen: boolean;
   showModal: boolean;
   showIntegrations: boolean;
+  userId: string | null;
 };
 
 type AppActions = {
@@ -66,6 +80,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [tweaksOpen, setTweaksOpen] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [showIntegrations, setShowIntegrations] = useState(false);
+  const [userId, setUserId] = useState<string | null>(null);
 
   useEffect(() => { document.documentElement.setAttribute('data-theme', theme); }, [theme]);
   useEffect(() => {
@@ -79,6 +94,28 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     document.documentElement.style.fontSize = `${14 * Number(m[density])}px`;
   }, [density]);
 
+  useEffect(() => {
+    /* v8 ignore next -- Supabase env vars are absent in the test environment */
+    if (!import.meta.env['VITE_SUPABASE_URL']) return;
+    const sub = subscribeAuthChange(async (session) => {
+      if (!session) { setUserId(null); return; }
+      const uid = session.user.id;
+      setUserId(uid);
+      const seeded = await hasSeededData(uid);
+      if (!seeded) {
+        await seedFromFixtures(uid, { trips: TRIPS, tripDetails: TRIP_DETAILS, insights: INSIGHTS, inbox: INBOX, travelers: TRAVELERS });
+      }
+      const [ts, ds, ins, inb] = await Promise.all([
+        fetchTrips(uid), fetchTripDetails(uid), fetchInsights(uid), fetchInboxItems(uid),
+      ]);
+      setTrips(ts);
+      setTripDetails(ds);
+      setInsights(ins);
+      setInbox(inb);
+    });
+    return () => sub.unsubscribe();
+  }, []);
+
   const searchedTrips = useMemo(() => {
     if (!search) return trips;
     const q = search.toLowerCase();
@@ -91,36 +128,71 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, [trips, search]);
 
   const moveStage = (tripId: string, stage: TripStage) =>
-    setTrips((ts) => ts.map((t) => (t.id === tripId ? { ...t, stage } : t)));
+    setTrips((ts) => {
+      const next = ts.map((t) => (t.id === tripId ? { ...t, stage } : t));
+      const updated = next.find((t) => t.id === tripId);
+      if (userId && updated) void upsertTrip(userId, updated);
+      return next;
+    });
 
   const updateTrip = (tripId: string, patch: Partial<Trip>) =>
-    setTrips((ts) => ts.map((t) => (t.id === tripId ? { ...t, ...patch } : t)));
+    setTrips((ts) => {
+      const next = ts.map((t) => (t.id === tripId ? { ...t, ...patch } : t));
+      const updated = next.find((t) => t.id === tripId);
+      if (userId && updated) void upsertTrip(userId, updated);
+      return next;
+    });
 
-  const addTrip = (trip: Trip) => setTrips((ts) => [...ts, trip]);
+  const addTrip = (trip: Trip) => {
+    setTrips((ts) => {
+      const next = [...ts, trip];
+      if (userId) void upsertTrip(userId, trip);
+      return next;
+    });
+  };
 
   const togglePacked = (tripId: string, idx: number) =>
-    setTripDetails((d) => ({
-      ...d,
-      [tripId]: {
-        ...d[tripId],
-        packing: d[tripId].packing.map((p, i) => (i === idx ? { ...p, packed: !p.packed } : p)),
-      },
-    }));
+    setTripDetails((d) => {
+      const next = {
+        ...d,
+        [tripId]: {
+          ...d[tripId],
+          packing: d[tripId].packing.map((p, i) => (i === idx ? { ...p, packed: !p.packed } : p)),
+        },
+      };
+      if (userId) void upsertTripDetail(userId, tripId, next[tripId]);
+      return next;
+    });
 
   const toggleBookingStatus = (tripId: string, idx: number, status: string) =>
-    setTripDetails((d) => ({
-      ...d,
-      [tripId]: {
-        ...d[tripId],
-        bookings: d[tripId].bookings.map((b, i) =>
-          i === idx ? { ...b, status: status as import('../lib/types').BookingStatus } : b,
-        ),
-      },
-    }));
+    setTripDetails((d) => {
+      const next = {
+        ...d,
+        [tripId]: {
+          ...d[tripId],
+          bookings: d[tripId].bookings.map((b, i) =>
+            i === idx ? { ...b, status: status as import('../lib/types').BookingStatus } : b,
+          ),
+        },
+      };
+      if (userId) void upsertTripDetail(userId, tripId, next[tripId]);
+      return next;
+    });
 
-  const dismissInsight = (id: string) => setInsights((ii) => ii.filter((i) => i.id !== id));
-  const dismissInboxItem = (id: string) => setInbox((ii) => ii.filter((i) => i.id !== id));
-  const assignInboxItem = (id: string) => setInbox((ii) => ii.filter((i) => i.id !== id));
+  const dismissInsight = (id: string) => {
+    setInsights((ii) => ii.filter((i) => i.id !== id));
+    if (userId) void deleteInsight(userId, id);
+  };
+
+  const dismissInboxItem = (id: string) => {
+    setInbox((ii) => ii.filter((i) => i.id !== id));
+    if (userId) void deleteInboxItem(userId, id);
+  };
+
+  const assignInboxItem = (id: string) => {
+    setInbox((ii) => ii.filter((i) => i.id !== id));
+    if (userId) void deleteInboxItem(userId, id);
+  };
 
   const toggleCategoryFilter = (key: string) =>
     setCategoryFilter((f) => (f.includes(key) ? f.filter((x) => x !== key) : [...f, key]));
@@ -130,6 +202,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       value={{
         trips, tripDetails, insights, inbox, search, categoryFilter,
         theme, accent, density, showInsights, tweaksOpen, showModal, showIntegrations,
+        userId,
         searchedTrips,
         moveStage, updateTrip, addTrip, togglePacked, toggleBookingStatus,
         dismissInsight, dismissInboxItem, assignInboxItem,

--- a/apps/web/src/app/AppContext.tsx
+++ b/apps/web/src/app/AppContext.tsx
@@ -98,7 +98,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     /* v8 ignore next -- Supabase env vars are absent in the test environment */
     if (!import.meta.env['VITE_SUPABASE_URL']) return;
     const sub = subscribeAuthChange(async (session) => {
-      if (!session) { setUserId(null); return; }
+      if (!session) {
+        setUserId(null);
+        setTrips([]);
+        setTripDetails({});
+        setInsights([]);
+        setInbox([]);
+        return;
+      }
       const uid = session.user.id;
       setUserId(uid);
       const seeded = await hasSeededData(uid);

--- a/apps/web/src/app/Login.test.tsx
+++ b/apps/web/src/app/Login.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/db', () => ({
+  signInWithMagicLink: vi.fn(),
+}));
+
+import { signInWithMagicLink } from '../lib/db';
+import { Login } from './Login';
+
+const mockSignIn = signInWithMagicLink as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('Login', () => {
+  it('renders email input and disabled submit button when empty', () => {
+    render(<Login />);
+    expect(screen.getByLabelText('Email address')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send magic link/i })).toBeDisabled();
+  });
+
+  it('enables submit button when email is entered', () => {
+    render(<Login />);
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'user@example.com' },
+    });
+    expect(screen.getByRole('button', { name: /send magic link/i })).not.toBeDisabled();
+  });
+
+  it('shows confirmation screen with email after successful sign-in', async () => {
+    mockSignIn.mockResolvedValue({ error: null });
+    render(<Login />);
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send magic link/i }));
+    await waitFor(() => expect(screen.getByText(/check your email/i)).toBeInTheDocument());
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+  });
+
+  it('shows error alert when sign-in fails', async () => {
+    mockSignIn.mockResolvedValue({ error: new Error('rate limited') });
+    render(<Login />);
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send magic link/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveTextContent('rate limited');
+  });
+
+  it('keeps submit button enabled after an error so the user can retry', async () => {
+    mockSignIn.mockResolvedValue({ error: new Error('oops') });
+    render(<Login />);
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send magic link/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /send magic link/i })).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/app/Login.tsx
+++ b/apps/web/src/app/Login.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { signInWithMagicLink } from '../lib/db';
+
+type LoginStep = 'form' | 'sent' | 'error';
+
+export function Login() {
+  const [email, setEmail] = useState('');
+  const [step, setStep] = useState<LoginStep>('form');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await signInWithMagicLink(email.trim());
+    if (error) {
+      setErrorMessage(error.message);
+      setStep('error');
+    } else {
+      setStep('sent');
+    }
+  };
+
+  if (step === 'sent') {
+    return (
+      <div className="login-confirm">
+        <h1>Check your email</h1>
+        <p>
+          We sent a magic link to <strong>{email}</strong>. Click the link to sign in.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="brand-mark">T</div>
+        <h1>Travel OS</h1>
+        <p>Sign in with a magic link — no password needed.</p>
+        <form onSubmit={handleSubmit}>
+          <div className="field">
+            <label htmlFor="login-email">Email address</label>
+            <input
+              id="login-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              autoFocus
+            />
+          </div>
+          {step === 'error' && (
+            <p role="alert" className="login-error">
+              {errorMessage}
+            </p>
+          )}
+          <button type="submit" className="btn primary" disabled={!email.trim()}>
+            Send magic link
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/router.test.tsx
+++ b/apps/web/src/app/router.test.tsx
@@ -1,13 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/db', () => ({
+  getSession: vi.fn(),
+  signInWithMagicLink: vi.fn(),
+  subscribeAuthChange: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+}));
+
 import { router } from './router';
 
 describe('app router', () => {
   it('declares expected top-level routes', () => {
-    expect(router.routes).toHaveLength(2);
+    expect(router.routes).toHaveLength(3);
     expect(router.routes[0].path).toBe('/');
-    expect(router.routes[1].path).toBe('/app');
+    expect(router.routes[1].path).toBe('/login');
+    expect(router.routes[2].path).toBe('/app');
 
-    const appChildren = router.routes[1].children ?? [];
+    const appChildren = router.routes[2].children ?? [];
     expect(appChildren.some((route) => route.path === 'pipeline')).toBe(true);
     expect(appChildren.some((route) => route.path === 'inbox')).toBe(true);
     expect(appChildren.some((route) => route.path === 'calendar')).toBe(true);

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -6,8 +6,9 @@ import {
   InboxPage,
   PipelinePage,
   TripDetailPage,
-  tripsLoader
+  authGuardLoader,
 } from './routes';
+import { Login } from './Login';
 
 export const router = createBrowserRouter([
   {
@@ -15,9 +16,13 @@ export const router = createBrowserRouter([
     element: <Navigate to="/app/pipeline" replace />
   },
   {
+    path: '/login',
+    element: <Login />,
+  },
+  {
     path: '/app',
     element: <AppLayout />,
-    loader: tripsLoader,
+    loader: authGuardLoader,
     children: [
       {
         index: true,

--- a/apps/web/src/app/routes.test.tsx
+++ b/apps/web/src/app/routes.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { TODAY, TRIPS, TRIP_DETAILS } from '../lib/data';
 import { AppProvider } from './AppContext';
 import {
@@ -10,10 +10,27 @@ import {
   InboxPage,
   PipelinePage,
   TripDetailPage,
+  authGuardLoader,
   greeting,
   localDateLabel,
   tripsLoader
 } from './routes';
+
+vi.mock('../lib/db', () => ({
+  getSession: vi.fn(),
+  subscribeAuthChange: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+  hasSeededData: vi.fn(),
+  seedFromFixtures: vi.fn(),
+  fetchTrips: vi.fn(),
+  fetchTripDetails: vi.fn(),
+  fetchInsights: vi.fn(),
+  fetchInboxItems: vi.fn(),
+  upsertTrip: vi.fn(),
+  upsertTripDetail: vi.fn(),
+  deleteInsight: vi.fn(),
+  deleteInboxItem: vi.fn(),
+}));
+import { getSession } from '../lib/db';
 
 const renderAt = (path: string, tripPath = 'trip/:tripId') => {
   return render(
@@ -269,5 +286,18 @@ describe('route components', () => {
       TRIPS.splice(TRIPS.findIndex((trip) => trip.id === customTrip.id), 1);
       TRIPS.splice(TRIPS.findIndex((trip) => trip.id === oneDayTrip.id), 1);
     }
+  });
+});
+
+describe('authGuardLoader', () => {
+  it('returns {} when a session exists', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { id: 'u1' } } as Awaited<ReturnType<typeof getSession>>);
+    expect(await authGuardLoader()).toEqual({});
+  });
+
+  it('returns a redirect Response when no session', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const result = await authGuardLoader();
+    expect(result).toBeInstanceOf(Response);
   });
 });

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link, NavLink, Outlet, useLocation, useParams } from 'react-router-dom';
+import { Link, NavLink, Outlet, redirect, useLocation, useParams } from 'react-router-dom';
+import { getSession } from '../lib/db';
 import { BOOKING_ICONS, Icon } from '../components/Icon';
 import { ArchiveDashboard } from '../components/ArchiveDashboard';
 import { CalendarDashboard } from '../components/CalendarDashboard';
@@ -63,6 +64,12 @@ const SOURCE_LABELS: Record<BookingSource | 'unknown', string> = {
 
 // No-op kept for router.tsx compatibility; AppLayout reads from AppContext instead.
 export const tripsLoader = () => ({});
+
+export async function authGuardLoader() {
+  const session = await getSession();
+  if (!session) return redirect('/login');
+  return {};
+}
 
 export function localDateLabel(utcDate: Date): string {
   return new Date(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate())

--- a/apps/web/src/components/components.test.tsx
+++ b/apps/web/src/components/components.test.tsx
@@ -1,6 +1,23 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/db', () => ({
+  getSession: vi.fn(),
+  signInWithMagicLink: vi.fn(),
+  subscribeAuthChange: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+  hasSeededData: vi.fn(),
+  seedFromFixtures: vi.fn(),
+  fetchTrips: vi.fn(),
+  fetchTripDetails: vi.fn(),
+  fetchInsights: vi.fn(),
+  fetchInboxItems: vi.fn(),
+  upsertTrip: vi.fn(),
+  upsertTripDetail: vi.fn(),
+  deleteInsight: vi.fn(),
+  deleteInboxItem: vi.fn(),
+}));
+
 import { AppProvider, useApp } from '../app/AppContext';
 import { INBOX, INSIGHTS, INTEGRATIONS, TODAY, TRIPS } from '../lib/data';
 import type { Trip } from '../lib/types';

--- a/apps/web/src/lib/db.test.ts
+++ b/apps/web/src/lib/db.test.ts
@@ -51,7 +51,7 @@ function makeChain(result: { data: unknown; error: unknown; count?: number }) {
 }
 
 const mockFrom = supabase.from as ReturnType<typeof vi.fn>;
-const mockAuth = supabase.auth as {
+const mockAuth = supabase.auth as unknown as {
   getSession: ReturnType<typeof vi.fn>;
   signInWithOtp: ReturnType<typeof vi.fn>;
   signOut: ReturnType<typeof vi.fn>;
@@ -228,7 +228,7 @@ describe('upsertTrip', () => {
     mockFrom.mockReturnValue(chain);
     const trip = {
       id: 'tr-1', destination: 'Rome', region: '', country: 'Italy',
-      stage: 'dreaming' as const, categories: [] as const, start_date: null,
+      stage: 'dreaming' as const, categories: [] as import('./types').TripCategory[], start_date: null,
       end_date: null, date_approx: null, budget_total: 0, budget_spent: 0,
       budget_currency: 'USD', travelers: [], cover: { hue: 42, label: 'terracotta' },
       notes: '', nights: 0,

--- a/apps/web/src/lib/db.test.ts
+++ b/apps/web/src/lib/db.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Trip, TripDetail, Insight, InboxItem, Traveler } from './types';
+
+vi.mock('./supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+      signInWithOtp: vi.fn(),
+      signOut: vi.fn(),
+      onAuthStateChange: vi.fn(),
+    },
+    from: vi.fn(),
+  },
+}));
+
+import { supabase } from './supabase';
+import {
+  getSession,
+  signInWithMagicLink,
+  signOut,
+  subscribeAuthChange,
+  hasSeededData,
+  fetchTrips,
+  fetchTripDetails,
+  fetchInsights,
+  fetchInboxItems,
+  fetchTravelers,
+  upsertTrip,
+  upsertTripDetail,
+  deleteInsight,
+  deleteInboxItem,
+  seedFromFixtures,
+} from './db';
+
+function makeChain(result: { data: unknown; error: unknown; count?: number }) {
+  const c = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    order: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+    then: (cb: (v: { data: unknown; error: unknown; count?: number }) => void) =>
+      Promise.resolve(cb(result)),
+  };
+  c.select.mockReturnValue(c);
+  c.eq.mockReturnValue(c);
+  c.order.mockReturnValue(c);
+  c.upsert.mockReturnValue(c);
+  c.delete.mockReturnValue(c);
+  return c;
+}
+
+const mockFrom = supabase.from as ReturnType<typeof vi.fn>;
+const mockAuth = supabase.auth as {
+  getSession: ReturnType<typeof vi.fn>;
+  signInWithOtp: ReturnType<typeof vi.fn>;
+  signOut: ReturnType<typeof vi.fn>;
+  onAuthStateChange: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+describe('getSession', () => {
+  it('returns session when one exists', async () => {
+    const session = { user: { id: 'u1' } };
+    mockAuth.getSession.mockResolvedValue({ data: { session } });
+    expect(await getSession()).toBe(session);
+  });
+
+  it('returns null when no session', async () => {
+    mockAuth.getSession.mockResolvedValue({ data: { session: null } });
+    expect(await getSession()).toBeNull();
+  });
+});
+
+describe('signInWithMagicLink', () => {
+  it('returns error: null on success', async () => {
+    mockAuth.signInWithOtp.mockResolvedValue({ error: null });
+    expect(await signInWithMagicLink('a@b.com')).toEqual({ error: null });
+  });
+
+  it('returns error on failure', async () => {
+    const err = new Error('rate limited');
+    mockAuth.signInWithOtp.mockResolvedValue({ error: err });
+    expect(await signInWithMagicLink('a@b.com')).toEqual({ error: err });
+  });
+});
+
+describe('signOut', () => {
+  it('calls supabase.auth.signOut', async () => {
+    mockAuth.signOut.mockResolvedValue({});
+    await signOut();
+    expect(mockAuth.signOut).toHaveBeenCalledOnce();
+  });
+});
+
+describe('subscribeAuthChange', () => {
+  it('registers a listener and returns unsubscribe', () => {
+    const unsubscribeFn = vi.fn();
+    mockAuth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: unsubscribeFn } },
+    });
+    const callback = vi.fn();
+    const sub = subscribeAuthChange(callback);
+    expect(mockAuth.onAuthStateChange).toHaveBeenCalledOnce();
+    sub.unsubscribe();
+    expect(unsubscribeFn).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Seed detection ────────────────────────────────────────────────────────────
+
+describe('hasSeededData', () => {
+  it('returns true when trips exist', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null, count: 3 }));
+    expect(await hasSeededData('u1')).toBe(true);
+  });
+
+  it('returns false when no trips', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null, count: 0 }));
+    expect(await hasSeededData('u1')).toBe(false);
+  });
+
+  it('returns false when count is null (nullish coalescing fallback)', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null, count: undefined }));
+    expect(await hasSeededData('u1')).toBe(false);
+  });
+});
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+
+describe('fetchTrips', () => {
+  it('maps cover_hue/cover_label back to cover object', async () => {
+    const row = {
+      id: 'tr-1', destination: 'Rome', region: 'Lazio', country: 'Italy',
+      stage: 'dreaming', categories: ['couple'], start_date: null, end_date: null,
+      date_approx: null, budget_total: 5000, budget_spent: 0, budget_currency: 'USD',
+      travelers: ['t1'], cover_hue: 30, cover_label: 'terra', notes: '', nights: 7,
+      created_days_ago: 10, days_in_stage: 10,
+    };
+    mockFrom.mockReturnValue(makeChain({ data: [row], error: null }));
+    const trips = await fetchTrips('u1');
+    expect(trips[0].cover).toEqual({ hue: 30, label: 'terra' });
+    expect(trips[0].destination).toBe('Rome');
+  });
+
+  it('returns empty array on error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db error') }));
+    expect(await fetchTrips('u1')).toEqual([]);
+  });
+});
+
+describe('fetchTripDetails', () => {
+  it('returns a Record keyed by trip_id', async () => {
+    const row = {
+      trip_id: 'tr-1', itinerary: [], bookings: [],
+      budget_breakdown: [], packing: [], documents: [],
+    };
+    mockFrom.mockReturnValue(makeChain({ data: [row], error: null }));
+    const details = await fetchTripDetails('u1');
+    expect(details['tr-1']).toBeDefined();
+    expect(details['tr-1'].bookings).toEqual([]);
+  });
+
+  it('returns empty object on error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db error') }));
+    expect(await fetchTripDetails('u1')).toEqual({});
+  });
+});
+
+describe('fetchInsights', () => {
+  it('returns insights array', async () => {
+    const row: Insight = {
+      id: 'i1', trip_id: 'tr-1', type: 'weather',
+      severity: 'info', title: 'Rain likely', body: 'Pack a jacket',
+    };
+    mockFrom.mockReturnValue(makeChain({ data: [row], error: null }));
+    const insights = await fetchInsights('u1');
+    expect(insights[0].id).toBe('i1');
+  });
+
+  it('returns empty array on error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db error') }));
+    expect(await fetchInsights('u1')).toEqual([]);
+  });
+});
+
+describe('fetchInboxItems', () => {
+  it('maps from_address to from field', async () => {
+    const row = {
+      id: 'ib1', source: 'email', vendor: 'AA', subject: 'Your flight',
+      from_address: 'aa@aa.com', received_ago: '2h ago', status: 'parsed',
+      parsed: null, suggested_trip: null, suggested_confidence: null, note: null,
+    };
+    mockFrom.mockReturnValue(makeChain({ data: [row], error: null }));
+    const items = await fetchInboxItems('u1');
+    expect(items[0].from).toBe('aa@aa.com');
+    expect(items[0].id).toBe('ib1');
+  });
+
+  it('returns empty array on error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db error') }));
+    expect(await fetchInboxItems('u1')).toEqual([]);
+  });
+});
+
+describe('fetchTravelers', () => {
+  it('returns travelers array', async () => {
+    const row: Traveler = { id: 't1', name: 'Quincy', relationship: 'self', initials: 'Q' };
+    mockFrom.mockReturnValue(makeChain({ data: [row], error: null }));
+    const travelers = await fetchTravelers('u1');
+    expect(travelers[0].name).toBe('Quincy');
+  });
+
+  it('returns empty array on error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db error') }));
+    expect(await fetchTravelers('u1')).toEqual([]);
+  });
+});
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+describe('upsertTrip', () => {
+  it('flattens cover into cover_hue and cover_label', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    const trip = {
+      id: 'tr-1', destination: 'Rome', region: '', country: 'Italy',
+      stage: 'dreaming' as const, categories: [] as const, start_date: null,
+      end_date: null, date_approx: null, budget_total: 0, budget_spent: 0,
+      budget_currency: 'USD', travelers: [], cover: { hue: 42, label: 'terracotta' },
+      notes: '', nights: 0,
+    };
+    await upsertTrip('u1', trip);
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ cover_hue: 42, cover_label: 'terracotta' }),
+      expect.any(Object),
+    );
+  });
+
+  it('swallows errors silently', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('fail') }));
+    const trip: Trip = {
+      id: 'tr-1', destination: 'X', region: '', country: '', stage: 'dreaming',
+      categories: [], start_date: null, end_date: null, date_approx: null,
+      budget_total: 0, budget_spent: 0, budget_currency: 'USD', travelers: [],
+      cover: { hue: 0, label: '' }, notes: '', nights: 0,
+    };
+    await expect(upsertTrip('u1', trip)).resolves.toBeUndefined();
+  });
+});
+
+describe('upsertTripDetail', () => {
+  it('calls upsert with jsonb fields', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    const detail: TripDetail = { itinerary: [], bookings: [], budget_breakdown: [], packing: [], documents: [] };
+    await upsertTripDetail('u1', 'tr-1', detail);
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ trip_id: 'tr-1', user_id: 'u1' }),
+      expect.any(Object),
+    );
+  });
+
+  it('swallows errors silently', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('fail') }));
+    const detail: TripDetail = { itinerary: [], bookings: [], budget_breakdown: [], packing: [], documents: [] };
+    await expect(upsertTripDetail('u1', 'tr-1', detail)).resolves.toBeUndefined();
+  });
+});
+
+describe('deleteInsight', () => {
+  it('calls delete with matching id and user_id', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await deleteInsight('u1', 'i1');
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('id', 'i1');
+    expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+  });
+
+  it('swallows errors silently', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('fail') }));
+    await expect(deleteInsight('u1', 'i1')).resolves.toBeUndefined();
+  });
+});
+
+describe('deleteInboxItem', () => {
+  it('calls delete with matching id and user_id', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await deleteInboxItem('u1', 'ib1');
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('id', 'ib1');
+    expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+  });
+
+  it('swallows errors silently', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('fail') }));
+    await expect(deleteInboxItem('u1', 'ib1')).resolves.toBeUndefined();
+  });
+});
+
+// ── Seed ──────────────────────────────────────────────────────────────────────
+
+describe('seedFromFixtures', () => {
+  const sampleTrip: Trip = {
+    id: 'tr-1', destination: 'Rome', region: 'Lazio', country: 'Italy',
+    stage: 'dreaming', categories: ['couple'], start_date: null, end_date: null,
+    date_approx: null, budget_total: 5000, budget_spent: 0, budget_currency: 'USD',
+    travelers: ['t1'], cover: { hue: 30, label: 'terra' }, notes: '', nights: 7,
+  };
+  const sampleDetail: TripDetail = {
+    itinerary: [], bookings: [], budget_breakdown: [], packing: [], documents: [],
+  };
+  const sampleInsight: Insight = {
+    id: 'i1', trip_id: 'tr-1', type: 'weather', severity: 'info', title: 'Rain', body: 'Pack coat',
+  };
+  const sampleInboxItem: InboxItem = {
+    id: 'ib1', source: 'email', vendor: 'AA', subject: 'Flight', from: 'aa@aa.com',
+    received_ago: '1h', status: 'parsed', parsed: null,
+    suggested_trip: 'tr-1', suggested_confidence: 0.9, note: 'auto-parsed',
+  };
+  const sampleTraveler: Traveler = { id: 't1', name: 'Quincy', relationship: 'self', initials: 'Q' };
+
+  const seedData = {
+    trips: [sampleTrip],
+    tripDetails: { 'tr-1': sampleDetail },
+    insights: [sampleInsight],
+    inbox: [sampleInboxItem],
+    travelers: [sampleTraveler],
+  };
+
+  it('upserts all tables when no seed data exists', async () => {
+    // hasSeededData returns false (count=0), then upserts succeed
+    const chain = makeChain({ data: null, error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    await seedFromFixtures('u1', seedData);
+    // from() called multiple times: once for hasSeededData check + once per table
+    expect(mockFrom).toHaveBeenCalled();
+    expect(chain.upsert).toHaveBeenCalled();
+  });
+
+  it('skips upserts when data already seeded', async () => {
+    // hasSeededData returns true (count=3)
+    const chain = makeChain({ data: null, error: null, count: 3 });
+    mockFrom.mockReturnValue(chain);
+    await seedFromFixtures('u1', seedData);
+    // from() only called once (the hasSeededData check) — no upserts
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -1,0 +1,242 @@
+import { supabase } from './supabase';
+import type { Trip, TripDetail, Insight, InboxItem, Traveler } from './types';
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+export async function getSession() {
+  const { data } = await supabase.auth.getSession();
+  return data.session;
+}
+
+export async function signInWithMagicLink(email: string): Promise<{ error: Error | null }> {
+  const { error } = await supabase.auth.signInWithOtp({ email });
+  return { error: error as Error | null };
+}
+
+export async function signOut(): Promise<void> {
+  await supabase.auth.signOut();
+}
+
+type AuthSession = Awaited<ReturnType<typeof getSession>>;
+
+export function subscribeAuthChange(
+  callback: (session: AuthSession) => void,
+): { unsubscribe: () => void } {
+  const { data: { subscription } } = supabase.auth.onAuthStateChange(
+    (_event, session) => callback(session),
+  );
+  return { unsubscribe: () => subscription.unsubscribe() };
+}
+
+// ── Seed detection ────────────────────────────────────────────────────────────
+
+export async function hasSeededData(userId: string): Promise<boolean> {
+  const { count } = await supabase
+    .from('trips')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId);
+  return (count ?? 0) > 0;
+}
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+
+export async function fetchTrips(userId: string): Promise<Trip[]> {
+  const { data, error } = await supabase
+    .from('trips')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at');
+  if (error || !data) return [];
+  return data.map((row) => ({
+    id: row.id as string,
+    destination: row.destination as string,
+    region: row.region as string,
+    country: row.country as string,
+    stage: row.stage as Trip['stage'],
+    categories: row.categories as Trip['categories'],
+    start_date: row.start_date as string | null,
+    end_date: row.end_date as string | null,
+    date_approx: row.date_approx as string | null,
+    budget_total: row.budget_total as number,
+    budget_spent: row.budget_spent as number,
+    budget_currency: row.budget_currency as string,
+    travelers: row.travelers as string[],
+    cover: { hue: row.cover_hue as number, label: row.cover_label as string },
+    notes: row.notes as string,
+    nights: row.nights as number,
+    created_days_ago: row.created_days_ago as number | undefined,
+    daysInStage: row.days_in_stage as number | undefined,
+  }));
+}
+
+export async function fetchTripDetails(userId: string): Promise<Record<string, TripDetail>> {
+  const { data, error } = await supabase
+    .from('trip_details')
+    .select('*')
+    .eq('user_id', userId);
+  if (error || !data) return {};
+  return Object.fromEntries(
+    data.map((row) => [
+      row.trip_id as string,
+      {
+        itinerary: row.itinerary as TripDetail['itinerary'],
+        bookings: row.bookings as TripDetail['bookings'],
+        budget_breakdown: row.budget_breakdown as TripDetail['budget_breakdown'],
+        packing: row.packing as TripDetail['packing'],
+        documents: row.documents as TripDetail['documents'],
+      },
+    ]),
+  );
+}
+
+export async function fetchInsights(userId: string): Promise<Insight[]> {
+  const { data, error } = await supabase
+    .from('insights')
+    .select('*')
+    .eq('user_id', userId);
+  if (error || !data) return [];
+  return data as Insight[];
+}
+
+export async function fetchInboxItems(userId: string): Promise<InboxItem[]> {
+  const { data, error } = await supabase
+    .from('inbox_items')
+    .select('*')
+    .eq('user_id', userId);
+  if (error || !data) return [];
+  return data.map((row) => ({
+    id: row.id as string,
+    source: row.source as InboxItem['source'],
+    vendor: row.vendor as string,
+    subject: row.subject as string,
+    from: row.from_address as string,
+    received_ago: row.received_ago as string,
+    status: row.status as InboxItem['status'],
+    parsed: row.parsed as InboxItem['parsed'],
+    suggested_trip: row.suggested_trip as string | undefined,
+    suggested_confidence: row.suggested_confidence as number | undefined,
+    note: row.note as string | undefined,
+  }));
+}
+
+export async function fetchTravelers(userId: string): Promise<Traveler[]> {
+  const { data, error } = await supabase
+    .from('travelers')
+    .select('*')
+    .eq('user_id', userId);
+  if (error || !data) return [];
+  return data as Traveler[];
+}
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+export async function upsertTrip(userId: string, trip: Trip): Promise<void> {
+  const { error } = await supabase.from('trips').upsert(
+    {
+      id: trip.id, user_id: userId,
+      destination: trip.destination, region: trip.region, country: trip.country,
+      stage: trip.stage, categories: trip.categories,
+      start_date: trip.start_date, end_date: trip.end_date, date_approx: trip.date_approx,
+      budget_total: trip.budget_total, budget_spent: trip.budget_spent,
+      budget_currency: trip.budget_currency, travelers: trip.travelers,
+      cover_hue: trip.cover.hue, cover_label: trip.cover.label,
+      notes: trip.notes, nights: trip.nights,
+    },
+    { onConflict: 'id,user_id' },
+  );
+  if (error) console.warn('[db] upsertTrip:', error.message);
+}
+
+export async function upsertTripDetail(
+  userId: string,
+  tripId: string,
+  detail: TripDetail,
+): Promise<void> {
+  const { error } = await supabase.from('trip_details').upsert(
+    {
+      trip_id: tripId, user_id: userId,
+      itinerary: detail.itinerary, bookings: detail.bookings,
+      budget_breakdown: detail.budget_breakdown, packing: detail.packing,
+      documents: detail.documents,
+    },
+    { onConflict: 'trip_id,user_id' },
+  );
+  if (error) console.warn('[db] upsertTripDetail:', error.message);
+}
+
+export async function deleteInsight(userId: string, id: string): Promise<void> {
+  const { error } = await supabase
+    .from('insights')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', userId);
+  if (error) console.warn('[db] deleteInsight:', error.message);
+}
+
+export async function deleteInboxItem(userId: string, id: string): Promise<void> {
+  const { error } = await supabase
+    .from('inbox_items')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', userId);
+  if (error) console.warn('[db] deleteInboxItem:', error.message);
+}
+
+// ── Seed ──────────────────────────────────────────────────────────────────────
+
+export async function seedFromFixtures(
+  userId: string,
+  data: {
+    trips: Trip[];
+    tripDetails: Record<string, TripDetail>;
+    insights: Insight[];
+    inbox: InboxItem[];
+    travelers: Traveler[];
+  },
+): Promise<void> {
+  if (await hasSeededData(userId)) return;
+
+  await Promise.all([
+    supabase.from('travelers').upsert(
+      data.travelers.map((t) => ({ ...t, user_id: userId })),
+      { onConflict: 'id,user_id' },
+    ),
+    supabase.from('trips').upsert(
+      data.trips.map((t) => ({
+        id: t.id, user_id: userId,
+        destination: t.destination, region: t.region, country: t.country,
+        stage: t.stage, categories: t.categories,
+        start_date: t.start_date, end_date: t.end_date, date_approx: t.date_approx,
+        budget_total: t.budget_total, budget_spent: t.budget_spent,
+        budget_currency: t.budget_currency, travelers: t.travelers,
+        cover_hue: t.cover.hue, cover_label: t.cover.label,
+        notes: t.notes, nights: t.nights,
+      })),
+      { onConflict: 'id,user_id' },
+    ),
+    supabase.from('trip_details').upsert(
+      Object.entries(data.tripDetails).map(([tripId, detail]) => ({
+        trip_id: tripId, user_id: userId,
+        itinerary: detail.itinerary, bookings: detail.bookings,
+        budget_breakdown: detail.budget_breakdown, packing: detail.packing,
+        documents: detail.documents,
+      })),
+      { onConflict: 'trip_id,user_id' },
+    ),
+    supabase.from('insights').upsert(
+      data.insights.map((i) => ({ ...i, user_id: userId })),
+      { onConflict: 'id,user_id' },
+    ),
+    supabase.from('inbox_items').upsert(
+      data.inbox.map((item) => ({
+        id: item.id, user_id: userId,
+        source: item.source, vendor: item.vendor, subject: item.subject,
+        from_address: item.from, received_ago: item.received_ago, status: item.status,
+        parsed: item.parsed, suggested_trip: item.suggested_trip,
+        suggested_confidence: item.suggested_confidence, note: item.note,
+      })),
+      { onConflict: 'id,user_id' },
+    ),
+  ]);
+}
+

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -2,7 +2,7 @@ import { createClient } from '@supabase/supabase-js';
 
 /* v8 ignore start */
 export const supabase = createClient(
-  import.meta.env['VITE_SUPABASE_URL'] as string,
-  import.meta.env['VITE_SUPABASE_ANON_KEY'] as string,
+  import.meta.env['VITE_SUPABASE_URL'] ?? 'https://placeholder.supabase.co',
+  import.meta.env['VITE_SUPABASE_ANON_KEY'] ?? 'placeholder-key',
 );
 /* v8 ignore end */

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+/* v8 ignore start */
+export const supabase = createClient(
+  import.meta.env['VITE_SUPABASE_URL'] as string,
+  import.meta.env['VITE_SUPABASE_ANON_KEY'] as string,
+);
+/* v8 ignore end */

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "travel-os",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.104.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1"
@@ -1527,6 +1528,92 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.1.tgz",
+      "integrity": "sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.1.tgz",
+      "integrity": "sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.1.tgz",
+      "integrity": "sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.1.tgz",
+      "integrity": "sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.1.tgz",
+      "integrity": "sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.1.tgz",
+      "integrity": "sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.104.1",
+        "@supabase/functions-js": "2.104.1",
+        "@supabase/postgrest-js": "2.104.1",
+        "@supabase/realtime-js": "2.104.1",
+        "@supabase/storage-js": "2.104.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1691,6 +1778,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1717,6 +1813,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3081,6 +3186,15 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4276,6 +4390,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4326,6 +4446,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4726,7 +4852,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.104.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["apps/web/src", "apps/web/vitest.setup.ts", "apps/web/src/**/*.test.ts", "apps/web/src/**/*.test.tsx"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         'apps/web/src/lib/types.ts',
         'apps/web/src/lib/data.ts',
         'apps/web/src/lib/utils.ts',
+        'apps/web/src/lib/supabase.ts',
         'apps/web/src/app/AppContext.tsx',
       ]
     }


### PR DESCRIPTION
- Install @supabase/supabase-js
- Create lib/supabase.ts (singleton client, v8-ignored)
- Create lib/db.ts with typed helpers: auth, fetch, upsert, delete, seed
- Add authGuardLoader to routes.tsx — redirects to /login when unauthenticated
- Add Login.tsx with magic-link form (form/sent/error states)
- Update router.tsx: add /login route, swap tripsLoader for authGuardLoader
- Update AppContext.tsx: Supabase auth subscription + optimistic sync on
  moveStage, updateTrip, addTrip, togglePacked, toggleBookingStatus,
  dismissInsight, dismissInboxItem, assignInboxItem
- Fixture data seeds Supabase on first login; subsequent loads read from DB
- All tests pass at 100% branch coverage (72 tests across 6 files)

Closes #8

https://claude.ai/code/session_0157iwb2yB4Npv4xnQRh6fBX