### PR TITLE
Upgrade Node.js version from 20 to 24 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## Summary
Updated the Node.js version used in the CI workflow to the latest major version.

## Changes
- Bumped Node.js version from 20 to 24 in the GitHub Actions CI workflow

## Details
This change updates the `node-version` configuration in the CI pipeline to use Node.js 24, ensuring the project is tested against the latest stable Node.js release. This helps maintain compatibility with current Node.js versions and allows the team to catch any potential issues early.

https://claude.ai/code/session_01YFnopij9dLyhmMvK3FsSSK