### PR TITLE
Add email ingestion API with Claude-powered parsing

### DIFF
--- a/apps/web/api/inbox/ingest.test.ts
+++ b/apps/web/api/inbox/ingest.test.ts
@@ -368,6 +368,44 @@ describe('ingest handler', () => {
     expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review' });
   });
 
+  it('returns 500 when the parsed-row update fails', async () => {
+    const supabase = makeSupabaseMock([]);
+    const anthropic = makeAnthropicMock(VALID_PARSED_JSON);
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: new Error('update failed') }) }),
+      };
+    });
+    const handler = createIngestHandler({ anthropic: anthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string; id: string };
+    expect(body.error).toBe('Failed to persist parsed item');
+    expect(typeof body.id).toBe('string');
+  });
+
+  it('rejects when raw.from is missing', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('POST', SECRET, { userId: 'u1', source: 'email', raw: { subject: 's', text: 't', receivedAt: '2026-04-25' } }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when raw.receivedAt is missing', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('POST', SECRET, { userId: 'u1', source: 'email', raw: { subject: 's', text: 't', from: 'f@f.com' } }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when userId is not a string', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('POST', SECRET, { userId: 42, source: 'email', raw: { subject: 's', text: 't', from: 'f@f.com', receivedAt: '2026-04-25' } }));
+    expect(res.status).toBe(400);
+  });
+
   it('uses "Parse error" fallback note when a non-Error is thrown', async () => {
     const throwingAnthropic: MockAnthropic = {
       // eslint-disable-next-line prefer-promise-reject-errors

--- a/apps/web/api/inbox/ingest.test.ts
+++ b/apps/web/api/inbox/ingest.test.ts
@@ -1,0 +1,395 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class Anthropic {
+    messages = { create: vi.fn() };
+  },
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: vi.fn() })),
+}));
+
+// Minimal typed interfaces for mocking Anthropic and Supabase
+interface MockAnthropic {
+  messages: { create: ReturnType<typeof vi.fn> };
+}
+
+interface MockSupabaseChain {
+  from: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  neq: ReturnType<typeof vi.fn>;
+  filter: ReturnType<typeof vi.fn>;
+  data: unknown;
+  error: unknown;
+}
+
+function makeSupabaseMock(
+  tripRows: unknown[] = [],
+  insertError: unknown = null,
+  updateError: unknown = null,
+) {
+  const chain: MockSupabaseChain = {
+    from: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+    eq: vi.fn(),
+    neq: vi.fn(),
+    filter: vi.fn(),
+    data: tripRows,
+    error: null,
+  };
+
+  // Each .from() call returns the chain; the chain's terminal returns depend on the operation
+  chain.from.mockImplementation((table: string) => {
+    if (table === 'trips') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            neq: vi.fn().mockResolvedValue({ data: tripRows, error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === 'inbox_items') {
+      return {
+        insert: vi.fn().mockResolvedValue({ error: insertError }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: updateError }),
+        }),
+      };
+    }
+    return chain;
+  });
+
+  return chain;
+}
+
+function makeAnthropicMock(jsonResponse: string): MockAnthropic {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: jsonResponse }],
+      }),
+    },
+  };
+}
+
+function makeRequest(
+  method: string,
+  secret: string | null,
+  body?: unknown,
+): Request {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (secret !== null) headers['x-ingest-secret'] = secret;
+  return new Request('http://localhost/api/inbox/ingest', {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+const VALID_BODY = {
+  userId: 'user-1',
+  source: 'email',
+  raw: { subject: 'Your flight confirmation', from: 'aa@aa.com', receivedAt: '2026-04-25', text: 'Flight AA123 confirmed.' },
+};
+
+const VALID_PARSED_JSON = JSON.stringify({
+  vendor: 'American Airlines',
+  type: 'flight',
+  title: 'AA123 JFK→LAX',
+  dates: '2026-05-02',
+  cost: 350,
+  confirmation: 'ABC123',
+  suggested_trip: 'tr-oaxaca',
+  suggested_confidence: 0.92,
+});
+
+import { createIngestHandler } from './ingest';
+
+describe('ingest handler', () => {
+  const SECRET = 'test-secret';
+
+  beforeEach(() => {
+    process.env['INGEST_SECRET'] = SECRET;
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('GET', SECRET));
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 405 for PUT method', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('PUT', SECRET, VALID_BODY));
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 401 when x-ingest-secret header is missing', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('POST', null, VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when x-ingest-secret header is wrong', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('POST', 'wrong-secret', VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when body is malformed JSON', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const req = new Request('http://localhost/api/inbox/ingest', {
+      method: 'POST',
+      headers: { 'x-ingest-secret': SECRET, 'content-type': 'application/json' },
+      body: 'not-json',
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body is missing required fields', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const res = await handler(makeRequest('POST', SECRET, { userId: 'u1' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body is JSON null (isValidBody falsy branch)', async () => {
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(VALID_PARSED_JSON) as never, supabase: makeSupabaseMock() as never });
+    const req = new Request('http://localhost/api/inbox/ingest', {
+      method: 'POST',
+      headers: { 'x-ingest-secret': SECRET, 'content-type': 'application/json' },
+      body: 'null',
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('happy path: inserts placeholder, calls Claude, updates to parsed with suggested trip', async () => {
+    const supabase = makeSupabaseMock([{ id: 'tr-oaxaca', destination: 'Oaxaca', country: 'Mexico', start_date: '2026-05-02', end_date: '2026-05-09', date_approx: null, stage: 'upcoming' }]);
+    const anthropic = makeAnthropicMock(VALID_PARSED_JSON);
+    const handler = createIngestHandler({ anthropic: anthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { id: string };
+    expect(typeof body.id).toBe('string');
+    expect(anthropic.messages.create).toHaveBeenCalledOnce();
+    const callArg = anthropic.messages.create.mock.calls[0][0] as { model: string };
+    expect(callArg.model).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('sets status needs_review when confidence is below 0.5', async () => {
+    const lowConfidence = JSON.stringify({
+      vendor: 'Unknown', type: 'flight', title: 'Some flight',
+      dates: '2026-05-01', cost: 100, confirmation: null,
+      suggested_trip: null, suggested_confidence: 0.3,
+    });
+    const supabase = makeSupabaseMock([]);
+    const anthropic = makeAnthropicMock(lowConfidence);
+
+    // Capture update calls to verify status
+    let capturedUpdatePayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockImplementation((payload: unknown) => {
+          capturedUpdatePayload = payload;
+          return { eq: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    });
+
+    const handler = createIngestHandler({ anthropic: anthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review' });
+  });
+
+  it('sets status needs_review when Claude returns invalid JSON', async () => {
+    const badJson = makeAnthropicMock('this is not json');
+    const supabase = makeSupabaseMock([]);
+    let capturedUpdatePayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockImplementation((payload: unknown) => {
+          capturedUpdatePayload = payload;
+          return { eq: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    });
+
+    const handler = createIngestHandler({ anthropic: badJson as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review' });
+  });
+
+  it('sets status needs_review and returns 200 when Claude throws', async () => {
+    const throwingAnthropic: MockAnthropic = {
+      messages: { create: vi.fn().mockRejectedValue(new Error('API down')) },
+    };
+    const supabase = makeSupabaseMock([]);
+    let capturedUpdatePayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockImplementation((payload: unknown) => {
+          capturedUpdatePayload = payload;
+          return { eq: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    });
+
+    const handler = createIngestHandler({ anthropic: throwingAnthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review', note: 'API down' });
+  });
+
+  it('returns 500 when initial insert fails', async () => {
+    const supabase = makeSupabaseMock([], new Error('DB insert failed'));
+    const anthropic = makeAnthropicMock(VALID_PARSED_JSON);
+    const handler = createIngestHandler({ anthropic: anthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(anthropic.messages.create).not.toHaveBeenCalled();
+  });
+
+  it('defaults source to "email" when not provided in body', async () => {
+    const supabase = makeSupabaseMock([]);
+    const anthropic = makeAnthropicMock(VALID_PARSED_JSON);
+    let capturedInsertPayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockImplementation((payload: unknown) => {
+          capturedInsertPayload = payload;
+          return Promise.resolve({ error: null });
+        }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+      };
+    });
+    const bodyNoSource = { userId: 'user-1', raw: { subject: 'X', from: 'x@x.com', receivedAt: '2026-04-25', text: 'body' } };
+    const handler = createIngestHandler({ anthropic: anthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, bodyNoSource));
+    expect(res.status).toBe(200);
+    expect(capturedInsertPayload).toMatchObject({ source: 'email' });
+  });
+
+  it('defaults suggested_confidence to 0 when null in parsed result', async () => {
+    const nullConfidenceJson = JSON.stringify({
+      vendor: 'AA', type: 'flight', title: 'Flight X',
+      dates: '2026-05-01', cost: 100, confirmation: null,
+      suggested_trip: null, suggested_confidence: null,
+    });
+    const supabase = makeSupabaseMock([]);
+    let capturedUpdatePayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockImplementation((payload: unknown) => {
+          capturedUpdatePayload = payload;
+          return { eq: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    });
+    const handler = createIngestHandler({ anthropic: makeAnthropicMock(nullConfidenceJson) as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review', suggested_confidence: 0 });
+  });
+
+  it('uses empty trip list when trips query returns null data', async () => {
+    const supabase = makeSupabaseMock([]);
+    const anthropic = makeAnthropicMock(VALID_PARSED_JSON);
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: null, error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+      };
+    });
+    const handler = createIngestHandler({ anthropic: anthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    const callArg = anthropic.messages.create.mock.calls[0][0] as { messages: Array<{ content: string }> };
+    expect(callArg.messages[0].content).toContain('[]');
+  });
+
+  it('treats non-text Claude content as empty string (falls through to needs_review)', async () => {
+    const nonTextAnthropic: MockAnthropic = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ type: 'tool_use', id: 'tu_1', name: 'fn', input: {} }],
+        }),
+      },
+    };
+    const supabase = makeSupabaseMock([]);
+    let capturedUpdatePayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockImplementation((payload: unknown) => {
+          capturedUpdatePayload = payload;
+          return { eq: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    });
+    const handler = createIngestHandler({ anthropic: nonTextAnthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review' });
+  });
+
+  it('uses "Parse error" fallback note when a non-Error is thrown', async () => {
+    const throwingAnthropic: MockAnthropic = {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      messages: { create: vi.fn().mockRejectedValue('raw string error') },
+    };
+    const supabase = makeSupabaseMock([]);
+    let capturedUpdatePayload: unknown;
+    supabase.from.mockImplementation((table: string) => {
+      if (table === 'trips') {
+        return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ neq: vi.fn().mockResolvedValue({ data: [], error: null }) }) }) };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockImplementation((payload: unknown) => {
+          capturedUpdatePayload = payload;
+          return { eq: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    });
+    const handler = createIngestHandler({ anthropic: throwingAnthropic as never, supabase: supabase as never });
+    const res = await handler(makeRequest('POST', SECRET, VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(capturedUpdatePayload).toMatchObject({ status: 'needs_review', note: 'Parse error' });
+  });
+});

--- a/apps/web/api/inbox/ingest.ts
+++ b/apps/web/api/inbox/ingest.ts
@@ -1,0 +1,131 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+
+interface IngestBody {
+  userId: string;
+  source?: string;
+  raw: { subject: string; from: string; receivedAt: string; text: string };
+}
+
+interface ParsedResult {
+  vendor: string;
+  type: string;
+  title: string;
+  dates: string;
+  cost: number;
+  confirmation: string | null;
+  suggested_trip: string | null;
+  suggested_confidence: number;
+}
+
+function isValidBody(b: unknown): b is IngestBody {
+  if (!b || typeof b !== 'object') return false;
+  const o = b as Record<string, unknown>;
+  return (
+    typeof o['userId'] === 'string' &&
+    !!o['raw'] &&
+    typeof (o['raw'] as Record<string, unknown>)['subject'] === 'string' &&
+    typeof (o['raw'] as Record<string, unknown>)['text'] === 'string'
+  );
+}
+
+export function createIngestHandler({
+  anthropic,
+  supabase,
+}: {
+  anthropic: Pick<Anthropic, 'messages'>;
+  supabase: SupabaseClient;
+}) {
+  return async (req: Request): Promise<Response> => {
+    if (req.method !== 'POST') {
+      return Response.json({ error: 'Method not allowed' }, { status: 405 });
+    }
+
+    const secret = req.headers.get('x-ingest-secret');
+    if (!secret || secret !== process.env['INGEST_SECRET']) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: IngestBody;
+    try {
+      const raw = await req.json();
+      if (!isValidBody(raw)) {
+        return Response.json({ error: 'Invalid body' }, { status: 400 });
+      }
+      body = raw;
+    } catch {
+      return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const id = randomUUID();
+    const { error: insertError } = await supabase.from('inbox_items').insert({
+      id,
+      user_id: body.userId,
+      source: body.source ?? 'email',
+      subject: body.raw.subject,
+      from_address: body.raw.from,
+      received_ago: body.raw.receivedAt,
+      status: 'parsing',
+      parsed: null,
+    });
+    if (insertError) {
+      return Response.json({ error: 'Failed to create inbox item' }, { status: 500 });
+    }
+
+    const { data: trips } = await supabase
+      .from('trips')
+      .select('id,destination,country,start_date,end_date,date_approx,stage')
+      .eq('user_id', body.userId)
+      .neq('stage', 'archived');
+
+    let parsed: ParsedResult | null = null;
+    try {
+      const message = await anthropic.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 512,
+        system:
+          'You are a travel confirmation email parser. Extract booking details and suggest which trip this belongs to. Return JSON only — no prose, no code fences.',
+        messages: [
+          {
+            role: 'user',
+            content: `Email subject: ${body.raw.subject}\nFrom: ${body.raw.from}\nBody:\n${body.raw.text}\n\nActive trips:\n${JSON.stringify(trips ?? [])}\n\nReturn JSON with keys: vendor, type (flight|lodging|transport|activity|dining|other), title, dates, cost (number), confirmation (string|null), suggested_trip (trip id|null), suggested_confidence (0-1).`,
+          },
+        ],
+      });
+      const first = message.content[0];
+      const text = first?.type === 'text' ? first.text : '';
+      parsed = JSON.parse(text) as ParsedResult;
+    } catch (err) {
+      const note = err instanceof Error ? err.message : 'Parse error';
+      await supabase.from('inbox_items').update({ status: 'needs_review', note }).eq('id', id);
+      return Response.json({ id }, { status: 200 });
+    }
+
+    const confidence = parsed.suggested_confidence ?? 0;
+    const status = confidence >= 0.5 ? 'parsed' : 'needs_review';
+    await supabase.from('inbox_items').update({
+      status,
+      vendor: parsed.vendor,
+      parsed: {
+        type: parsed.type,
+        title: parsed.title,
+        dates: parsed.dates,
+        cost: parsed.cost,
+        confirmation: parsed.confirmation,
+      },
+      suggested_trip: parsed.suggested_trip,
+      suggested_confidence: confidence,
+    }).eq('id', id);
+
+    return Response.json({ id }, { status: 200 });
+  };
+}
+
+export default createIngestHandler({
+  anthropic: new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] }),
+  supabase: createClient(
+    process.env['SUPABASE_URL'] ?? '',
+    process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '',
+  ),
+});

--- a/apps/web/api/inbox/ingest.ts
+++ b/apps/web/api/inbox/ingest.ts
@@ -22,11 +22,13 @@ interface ParsedResult {
 function isValidBody(b: unknown): b is IngestBody {
   if (!b || typeof b !== 'object') return false;
   const o = b as Record<string, unknown>;
+  if (typeof o['userId'] !== 'string' || !o['raw']) return false;
+  const r = o['raw'] as Record<string, unknown>;
   return (
-    typeof o['userId'] === 'string' &&
-    !!o['raw'] &&
-    typeof (o['raw'] as Record<string, unknown>)['subject'] === 'string' &&
-    typeof (o['raw'] as Record<string, unknown>)['text'] === 'string'
+    typeof r['subject'] === 'string' &&
+    typeof r['text'] === 'string' &&
+    typeof r['from'] === 'string' &&
+    typeof r['receivedAt'] === 'string'
   );
 }
 
@@ -104,7 +106,7 @@ export function createIngestHandler({
 
     const confidence = parsed.suggested_confidence ?? 0;
     const status = confidence >= 0.5 ? 'parsed' : 'needs_review';
-    await supabase.from('inbox_items').update({
+    const { error: updateError } = await supabase.from('inbox_items').update({
       status,
       vendor: parsed.vendor,
       parsed: {
@@ -117,6 +119,9 @@ export function createIngestHandler({
       suggested_trip: parsed.suggested_trip,
       suggested_confidence: confidence,
     }).eq('id', id);
+    if (updateError) {
+      return Response.json({ error: 'Failed to persist parsed item', id }, { status: 500 });
+    }
 
     return Response.json({ id }, { status: 200 });
   };

--- a/apps/web/src/app/AppContext.tsx
+++ b/apps/web/src/app/AppContext.tsx
@@ -10,6 +10,7 @@ import {
   hasSeededData,
   seedFromFixtures,
   subscribeAuthChange,
+  subscribeInbox,
   upsertTrip,
   upsertTripDetail,
 } from '../lib/db';
@@ -97,7 +98,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     /* v8 ignore next -- Supabase env vars are absent in the test environment */
     if (!import.meta.env['VITE_SUPABASE_URL']) return;
+    let inboxSub: { unsubscribe: () => void } | null = null;
     const sub = subscribeAuthChange(async (session) => {
+      inboxSub?.unsubscribe();
+      inboxSub = null;
       if (!session) {
         setUserId(null);
         setTrips([]);
@@ -119,8 +123,20 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       setTripDetails(ds);
       setInsights(ins);
       setInbox(inb);
+      inboxSub = subscribeInbox(uid, (change) => {
+        if (change.eventType === 'DELETE') {
+          setInbox((ii) => ii.filter((i) => i.id !== change.id));
+        } else if (change.eventType === 'INSERT') {
+          setInbox((ii) => [...ii.filter((i) => i.id !== change.item.id), change.item]);
+        } else {
+          setInbox((ii) => ii.map((i) => (i.id === change.item.id ? change.item : i)));
+        }
+      });
     });
-    return () => sub.unsubscribe();
+    return () => {
+      inboxSub?.unsubscribe();
+      sub.unsubscribe();
+    };
   }, []);
 
   const searchedTrips = useMemo(() => {

--- a/apps/web/src/lib/db.test.ts
+++ b/apps/web/src/lib/db.test.ts
@@ -10,6 +10,8 @@ vi.mock('./supabase', () => ({
       onAuthStateChange: vi.fn(),
     },
     from: vi.fn(),
+    channel: vi.fn(),
+    removeChannel: vi.fn(),
   },
 }));
 
@@ -29,6 +31,8 @@ import {
   upsertTripDetail,
   deleteInsight,
   deleteInboxItem,
+  insertInboxItem,
+  subscribeInbox,
   seedFromFixtures,
 } from './db';
 
@@ -38,6 +42,7 @@ function makeChain(result: { data: unknown; error: unknown; count?: number }) {
     eq: vi.fn(),
     order: vi.fn(),
     upsert: vi.fn(),
+    insert: vi.fn(),
     delete: vi.fn(),
     then: (cb: (v: { data: unknown; error: unknown; count?: number }) => void) =>
       Promise.resolve(cb(result)),
@@ -46,6 +51,7 @@ function makeChain(result: { data: unknown; error: unknown; count?: number }) {
   c.eq.mockReturnValue(c);
   c.order.mockReturnValue(c);
   c.upsert.mockReturnValue(c);
+  c.insert.mockReturnValue(c);
   c.delete.mockReturnValue(c);
   return c;
 }
@@ -56,6 +62,10 @@ const mockAuth = supabase.auth as unknown as {
   signInWithOtp: ReturnType<typeof vi.fn>;
   signOut: ReturnType<typeof vi.fn>;
   onAuthStateChange: ReturnType<typeof vi.fn>;
+};
+const mockSupabase = supabase as unknown as {
+  channel: ReturnType<typeof vi.fn>;
+  removeChannel: ReturnType<typeof vi.fn>;
 };
 
 beforeEach(() => vi.clearAllMocks());
@@ -333,6 +343,110 @@ describe('deleteInboxItem', () => {
   it('swallows errors silently', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('fail') }));
     await expect(deleteInboxItem('u1', 'ib1')).resolves.toBeUndefined();
+  });
+});
+
+describe('insertInboxItem', () => {
+  it('inserts a row mapping from → from_address', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    const item: InboxItem = {
+      id: 'ib-new', source: 'email', vendor: 'AA', subject: 'Your flight',
+      from: 'aa@aa.com', received_ago: '1h ago', status: 'parsing', parsed: null,
+    };
+    await insertInboxItem('u1', item);
+    expect(chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'ib-new', user_id: 'u1', from_address: 'aa@aa.com', status: 'parsing' }),
+    );
+  });
+
+  it('logs a warning on error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('fail') }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const item: InboxItem = {
+      id: 'ib-x', source: 'email', vendor: 'X', subject: 'X',
+      from: 'x@x.com', received_ago: '1h', status: 'parsing', parsed: null,
+    };
+    await insertInboxItem('u1', item);
+    expect(warnSpy).toHaveBeenCalledWith('[db] insertInboxItem:', 'fail');
+    warnSpy.mockRestore();
+  });
+});
+
+describe('subscribeInbox', () => {
+  function makeChannelObj() {
+    let capturedCb: ((payload: unknown) => void) | undefined;
+    const subscribe = vi.fn();
+    const on = vi.fn().mockImplementation((_event: string, _filter: unknown, cb: (payload: unknown) => void) => {
+      capturedCb = cb;
+      return channelObj;
+    });
+    const channelObj = { on, subscribe };
+    subscribe.mockReturnValue(channelObj);
+    return { channelObj, getCapturedCb: () => capturedCb };
+  }
+
+  it('subscribes with correct table, event, and filter', () => {
+    const { channelObj } = makeChannelObj();
+    mockSupabase.channel.mockReturnValue(channelObj);
+    subscribeInbox('u1', vi.fn());
+    expect(mockSupabase.channel).toHaveBeenCalledWith(expect.any(String));
+    expect(channelObj.on).toHaveBeenCalledWith(
+      'postgres_changes',
+      expect.objectContaining({ event: '*', schema: 'public', table: 'inbox_items', filter: 'user_id=eq.u1' }),
+      expect.any(Function),
+    );
+  });
+
+  it('unsubscribe calls removeChannel with the channel object', () => {
+    const { channelObj } = makeChannelObj();
+    mockSupabase.channel.mockReturnValue(channelObj);
+    const sub = subscribeInbox('u1', vi.fn());
+    sub.unsubscribe();
+    expect(mockSupabase.removeChannel).toHaveBeenCalledWith(channelObj);
+  });
+
+  it('maps INSERT payload row to InboxItem and calls onChange', () => {
+    const { channelObj, getCapturedCb } = makeChannelObj();
+    mockSupabase.channel.mockReturnValue(channelObj);
+    const handler = vi.fn();
+    subscribeInbox('u1', handler);
+    const row = {
+      id: 'ib1', source: 'email', vendor: 'AA', subject: 'Flight',
+      from_address: 'aa@aa.com', received_ago: '1h', status: 'parsed',
+      parsed: null, suggested_trip: 'tr-1', suggested_confidence: 0.9, note: 'auto',
+    };
+    getCapturedCb()!({ eventType: 'INSERT', new: row, old: {} });
+    expect(handler).toHaveBeenCalledWith({
+      eventType: 'INSERT',
+      item: expect.objectContaining({ id: 'ib1', from: 'aa@aa.com', vendor: 'AA', status: 'parsed' }),
+    });
+  });
+
+  it('maps UPDATE payload row to InboxItem and calls onChange', () => {
+    const { channelObj, getCapturedCb } = makeChannelObj();
+    mockSupabase.channel.mockReturnValue(channelObj);
+    const handler = vi.fn();
+    subscribeInbox('u1', handler);
+    const row = {
+      id: 'ib2', source: 'gmail', vendor: 'UA', subject: 'Updated',
+      from_address: 'ua@ua.com', received_ago: '2h', status: 'needs_review',
+      parsed: null, suggested_trip: undefined, suggested_confidence: undefined, note: undefined,
+    };
+    getCapturedCb()!({ eventType: 'UPDATE', new: row, old: {} });
+    expect(handler).toHaveBeenCalledWith({
+      eventType: 'UPDATE',
+      item: expect.objectContaining({ id: 'ib2', from: 'ua@ua.com', status: 'needs_review' }),
+    });
+  });
+
+  it('maps DELETE payload to id-only change and calls onChange', () => {
+    const { channelObj, getCapturedCb } = makeChannelObj();
+    mockSupabase.channel.mockReturnValue(channelObj);
+    const handler = vi.fn();
+    subscribeInbox('u1', handler);
+    getCapturedCb()!({ eventType: 'DELETE', new: {}, old: { id: 'ib3' } });
+    expect(handler).toHaveBeenCalledWith({ eventType: 'DELETE', id: 'ib3' });
   });
 });
 

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -99,13 +99,8 @@ export async function fetchInsights(userId: string): Promise<Insight[]> {
   return data as Insight[];
 }
 
-export async function fetchInboxItems(userId: string): Promise<InboxItem[]> {
-  const { data, error } = await supabase
-    .from('inbox_items')
-    .select('*')
-    .eq('user_id', userId);
-  if (error || !data) return [];
-  return data.map((row) => ({
+function rowToInboxItem(row: Record<string, unknown>): InboxItem {
+  return {
     id: row.id as string,
     source: row.source as InboxItem['source'],
     vendor: row.vendor as string,
@@ -117,7 +112,16 @@ export async function fetchInboxItems(userId: string): Promise<InboxItem[]> {
     suggested_trip: row.suggested_trip as string | undefined,
     suggested_confidence: row.suggested_confidence as number | undefined,
     note: row.note as string | undefined,
-  }));
+  };
+}
+
+export async function fetchInboxItems(userId: string): Promise<InboxItem[]> {
+  const { data, error } = await supabase
+    .from('inbox_items')
+    .select('*')
+    .eq('user_id', userId);
+  if (error || !data) return [];
+  return data.map(rowToInboxItem);
 }
 
 export async function fetchTravelers(userId: string): Promise<Traveler[]> {
@@ -181,6 +185,49 @@ export async function deleteInboxItem(userId: string, id: string): Promise<void>
     .eq('id', id)
     .eq('user_id', userId);
   if (error) console.warn('[db] deleteInboxItem:', error.message);
+}
+
+export async function insertInboxItem(userId: string, item: InboxItem): Promise<void> {
+  const { error } = await supabase.from('inbox_items').insert({
+    id: item.id,
+    user_id: userId,
+    source: item.source,
+    vendor: item.vendor,
+    subject: item.subject,
+    from_address: item.from,
+    received_ago: item.received_ago,
+    status: item.status,
+    parsed: item.parsed,
+    suggested_trip: item.suggested_trip,
+    suggested_confidence: item.suggested_confidence,
+    note: item.note,
+  });
+  if (error) console.warn('[db] insertInboxItem:', error.message);
+}
+
+type InboxChange =
+  | { eventType: 'INSERT' | 'UPDATE'; item: InboxItem }
+  | { eventType: 'DELETE'; id: string };
+
+export function subscribeInbox(
+  userId: string,
+  onChange: (change: InboxChange) => void,
+): { unsubscribe: () => void } {
+  const channel = supabase
+    .channel('inbox_changes')
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'inbox_items', filter: `user_id=eq.${userId}` },
+      (payload: { eventType: string; new: Record<string, unknown>; old: Record<string, unknown> }) => {
+        if (payload.eventType === 'DELETE') {
+          onChange({ eventType: 'DELETE', id: payload.old['id'] as string });
+        } else {
+          onChange({ eventType: payload.eventType as 'INSERT' | 'UPDATE', item: rowToInboxItem(payload.new) });
+        }
+      },
+    )
+    .subscribe();
+  return { unsubscribe: () => supabase.removeChannel(channel) };
 }
 
 // ── Seed ──────────────────────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "travel-os",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
         "@supabase/supabase-js": "^2.104.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -51,6 +52,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -312,7 +333,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3421,6 +3441,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4377,6 +4410,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -4910,7 +4949,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.91.1",
     "@supabase/supabase-js": "^2.104.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom", "node"]
   },
-  "include": ["apps/web/src", "apps/web/vitest.setup.ts", "apps/web/src/**/*.test.ts", "apps/web/src/**/*.test.tsx"]
+  "include": ["apps/web/src", "apps/web/vitest.setup.ts", "apps/web/src/**/*.test.ts", "apps/web/src/**/*.test.tsx", "apps/web/api"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         functions: 100,
         lines: 100
       },
-      include: ['apps/web/src/app/**/*.{ts,tsx}', 'apps/web/src/components/**/*.{ts,tsx}', 'apps/web/src/lib/**/*.ts'],
+      include: ['apps/web/src/app/**/*.{ts,tsx}', 'apps/web/src/components/**/*.{ts,tsx}', 'apps/web/src/lib/**/*.ts', 'apps/web/api/**/*.ts'],
       exclude: [
         '**/*.test.{ts,tsx}',
         'apps/web/src/lib/types.ts',


### PR DESCRIPTION
## Summary
This PR adds a new email ingestion API endpoint that accepts travel confirmation emails, uses Claude to parse them into structured booking data, and stores the results in the inbox. It also adds real-time subscription support for inbox changes.

## Key Changes

### New Ingestion API (`apps/web/api/inbox/ingest.ts`)
- Created `POST /api/inbox/ingest` endpoint that:
  - Validates incoming requests with secret-based authentication
  - Accepts email metadata (subject, from, body, received date)
  - Creates a placeholder inbox item with `parsing` status
  - Calls Claude Haiku to extract booking details (vendor, type, dates, cost, confirmation number)
  - Matches parsed bookings to user's active trips with confidence scoring
  - Updates inbox item with parsed data or marks as `needs_review` if confidence < 0.5 or parsing fails
  - Returns gracefully on errors (sets status to `needs_review` with error note)

### Database Functions (`apps/web/src/lib/db.ts`)
- Added `insertInboxItem()` to insert new inbox items from the API
- Added `subscribeInbox()` for real-time inbox updates via Supabase Postgres Changes
- Extracted `rowToInboxItem()` helper to map database rows to `InboxItem` objects
- Subscription handles INSERT, UPDATE, and DELETE events with proper field mapping (`from_address` → `from`)

### UI Integration (`apps/web/src/app/AppContext.tsx`)
- Integrated inbox subscription into `AppProvider`
- Subscribes to inbox changes when user authenticates
- Unsubscribes when user logs out
- Updates local inbox state on INSERT, UPDATE, and DELETE events

### Testing
- Added comprehensive test suite (`apps/web/api/inbox/ingest.test.ts`) with 395 lines covering:
  - Authentication and authorization
  - Request validation
  - Happy path with trip matching
  - Error handling (invalid JSON, API failures, parsing errors)
  - Edge cases (null confidence, non-text Claude responses, missing optional fields)
- Updated `apps/web/src/lib/db.test.ts` with tests for new `insertInboxItem()` and `subscribeInbox()` functions

### Configuration
- Added `@anthropic-ai/sdk` dependency
- Updated TypeScript config to include Node types for crypto module
- Updated Vite coverage config to include API routes

## Implementation Details
- Uses Claude Haiku 4.5 for cost-effective parsing
- Implements graceful degradation: parsing errors don't fail the request, just mark item for review
- Supports optional `source` field (defaults to "email")
- Handles null/undefined confidence values (defaults to 0)
- Provides detailed error notes when parsing fails

https://claude.ai/code/session_01DhKZY3rczUKnNeXdSg5v5t