### PR TITLE
Add email ingestion API with Claude AI parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A personal trip-management app — pipeline, inbox, calendar, budget, packing, a
 | UI | React 18 + TypeScript (strict) |
 | Build / dev server | Vite 5 |
 | Routing | React Router v6 |
-| Backend | Supabase (Postgres + magic-link auth) |
+| Backend | Supabase (Postgres + magic-link auth + Realtime) |
+| AI | Anthropic Claude Haiku (email parsing via `@anthropic-ai/sdk`) |
 | Unit tests | Vitest + Testing Library (100% branch coverage enforced) |
 | E2E / visual tests | Playwright (Chromium, with screenshot regression) |
 | Styling | Vanilla CSS with design-token variables |
@@ -27,15 +28,64 @@ A personal trip-management app — pipeline, inbox, calendar, budget, packing, a
 ## Prerequisites
 
 - Node.js ≥ 20
-- A [Supabase](https://supabase.com) project with magic-link (OTP) auth enabled
+- A [Supabase](https://supabase.com) account
+- An [Anthropic](https://console.anthropic.com) account (for the email ingestion API)
+- A [Vercel](https://vercel.com) account (for deployment)
 
-## Setup
+## Service setup
+
+### 1. Supabase
+
+Supabase provides the database, authentication, and real-time subscriptions.
+
+1. Go to [supabase.com](https://supabase.com) and create a new project.
+2. Once provisioned, open **Authentication → Providers** and ensure **Email** is enabled (magic-link / OTP — no password required).
+3. Open **Settings → API** and copy:
+   - **Project URL** → `VITE_SUPABASE_URL` and `SUPABASE_URL`
+   - **anon / public key** → `VITE_SUPABASE_ANON_KEY`
+   - **service_role key** → `SUPABASE_SERVICE_ROLE_KEY` (keep this secret — it bypasses row-level security)
+4. Run the database migrations in `supabase/migrations/` against your project (via the Supabase CLI or the SQL editor in the dashboard).
+5. In **Realtime → Tables**, make sure `inbox_items` is enabled for broadcasts so the UI receives live updates.
+
+### 2. Anthropic
+
+Claude Haiku parses forwarded booking emails into structured data.
+
+1. Sign in at [console.anthropic.com](https://console.anthropic.com).
+2. Go to **API Keys** and create a new key.
+3. Copy the key → `ANTHROPIC_API_KEY`.
+
+### 3. Vercel (deployment)
+
+1. Import the repository in the [Vercel dashboard](https://vercel.com/new).
+2. Set the **Root Directory** to `.` (the repo root) — Vite and the API functions are both configured from `vite.config.ts` and `vercel.json`.
+3. Add all environment variables from the table below in **Settings → Environment Variables**.
+4. Deploy. Vercel automatically routes `apps/web/api/**` as serverless functions.
+
+To send a test email to the ingest endpoint after deploying:
+
+```bash
+curl -X POST https://<your-vercel-domain>/api/inbox/ingest \
+  -H "Content-Type: application/json" \
+  -H "x-ingest-secret: <INGEST_SECRET>" \
+  -d '{
+    "userId": "<supabase-user-uuid>",
+    "raw": {
+      "subject": "Your flight confirmation",
+      "from": "bookings@airline.com",
+      "receivedAt": "2026-04-25",
+      "text": "Flight AA123 JFK→LAX confirmed for 2 May 2026."
+    }
+  }'
+```
+
+## Local setup
 
 ```bash
 git clone <repo-url>
 cd travel-os
 npm install
-cp .env.example .env   # fill in your Supabase credentials
+cp .env.example .env   # fill in your credentials (see Environment variables below)
 npm run dev
 ```
 
@@ -45,12 +95,25 @@ On first login the app seeds fixture trips, bookings, and inbox items so you hav
 
 ## Environment variables
 
+### Client-side (Vite)
+
 | Variable | Description |
 |---|---|
 | `VITE_SUPABASE_URL` | Your Supabase project URL |
 | `VITE_SUPABASE_ANON_KEY` | Your Supabase anonymous (public) key |
 
 Both values are available in your Supabase project under **Settings → API**.
+
+### Server-side (email ingestion API)
+
+| Variable | Description |
+|---|---|
+| `SUPABASE_URL` | Your Supabase project URL (server-side, without `VITE_` prefix) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service-role key — bypasses RLS; keep secret |
+| `ANTHROPIC_API_KEY` | Anthropic API key used by Claude Haiku to parse emails |
+| `INGEST_SECRET` | Arbitrary secret sent in `x-ingest-secret` header to authenticate ingest requests |
+
+`SUPABASE_SERVICE_ROLE_KEY` and `ANTHROPIC_API_KEY` are available in your Supabase project (**Settings → API**) and [Anthropic Console](https://console.anthropic.com) respectively.
 
 ## Scripts
 
@@ -90,15 +153,36 @@ Commit the updated PNGs in `e2e/__snapshots__/` as part of the same PR.
 
 ## Architecture
 
+### Diagram
+
+```mermaid
+graph TD
+    Browser["User Browser"] -->|"React SPA (Vite)"| Vercel["Vercel\nStatic + Functions"]
+    Vercel -->|"auth / CRUD"| Supabase["Supabase\nPostgres · Auth · Realtime"]
+    Supabase -->|"Realtime inbox_items changes"| Vercel
+    Email["Email client\n(forward / webhook)"] -->|"POST /api/inbox/ingest\nx-ingest-secret header"| Vercel
+    Vercel -->|"parse email body"| Claude["Anthropic\nClaude Haiku"]
+    Claude -->|"structured booking JSON"| Vercel
+    Vercel -->|"insert / update inbox_items"| Supabase
 ```
-apps/web/src/
-  app/         — AppLayout, AppContext (all global state), router, Login
-  components/  — PipelineDashboard, InboxDashboard, CalendarDashboard,
-                 ArchiveDashboard, TripCard, modals/, …
-  lib/         — types.ts, db.ts (Supabase CRUD), data.ts (fixtures), utils.ts
+
+### Code layout
+
+```
+apps/web/
+  src/
+    app/         — AppLayout, AppContext (all global state), router, Login
+    components/  — PipelineDashboard, InboxDashboard, CalendarDashboard,
+                   ArchiveDashboard, TripCard, modals/, …
+    lib/         — types.ts, db.ts (Supabase CRUD + Realtime), data.ts (fixtures), utils.ts
+  api/
+    inbox/
+      ingest.ts  — POST /api/inbox/ingest (Claude-powered email parsing)
 ```
 
 All state lives in `AppContext`. Every mutation flows through `AppContext` actions → `lib/db.ts` → Supabase. Components read state via the `useApp()` hook and never manage trip data locally.
+
+The `api/inbox/ingest.ts` endpoint runs server-side on Vercel Functions. It accepts a forwarded email, creates a placeholder inbox item, calls Claude Haiku to extract booking details, and updates the item with parsed data or marks it `needs_review` if confidence is below 0.5. The inbox subscribes to Supabase Realtime so the UI updates automatically when items are inserted or updated.
 
 ## Development workflow
 


### PR DESCRIPTION
## Summary

This PR adds an email ingestion system that allows users to forward booking confirmation emails to the app. A new serverless API endpoint parses emails using Claude Haiku to extract structured booking data and automatically creates inbox items.

## Key Changes

- **New API endpoint** (`apps/web/api/inbox/ingest.ts`): Accepts forwarded emails via POST request, authenticates with `x-ingest-secret` header, and processes them server-side
- **Claude Haiku integration**: Uses Anthropic's Claude Haiku model to parse email bodies and extract booking details into structured JSON
- **Inbox automation**: Creates placeholder inbox items that are updated with parsed booking data or marked `needs_review` if confidence is below 0.5
- **Real-time sync**: Leverages Supabase Realtime on `inbox_items` table so the UI automatically reflects newly ingested emails
- **Updated documentation**: 
  - Added Anthropic and Vercel to tech stack
  - Comprehensive service setup guide for Supabase, Anthropic, and Vercel deployment
  - Added architecture diagram showing email flow through Claude
  - Included curl example for testing the ingest endpoint
  - Separated environment variables into client-side (Vite) and server-side (API) sections
  - Updated code layout to document the new `api/inbox/` directory

## Implementation Details

- The endpoint is deployed as a Vercel serverless function and automatically routed via `vercel.json` configuration
- Server-side environment variables (`SUPABASE_SERVICE_ROLE_KEY`, `ANTHROPIC_API_KEY`, `INGEST_SECRET`) are kept separate from client-side variables to maintain security
- Email parsing confidence threshold (0.5) determines whether items are auto-populated or flagged for manual review
- The system integrates seamlessly with existing AppContext state management and Supabase CRUD operations

https://claude.ai/code/session_013vXrGqdPBwn599uNiBAPdV